### PR TITLE
Fix repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Screen Vision is designed to process your data securely without retaining it.
 Clone the repo and install dependencies:
 
 ```bash
-git clone https://github.com/bullmeza/screen-vision.git
-cd screen-vision
+git clone https://github.com/bullmeza/screen.vision.git
+cd screen.vision
 
 # Frontend
 pnpm install


### PR DESCRIPTION
I noticed the repo url mentioned in the Readme ("screen-vision") differs from the actual repo url ("screen.vision").